### PR TITLE
Updated Preferences: Ruleset Options and General

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -580,14 +580,14 @@
     "description": "Label for button in views menu button"
   },
 
-  "exportButtonLabel": {
+  "exportDataButtonLabel": {
     "message": "Export Data",
-    "description": "Label for rerun export button in the footer of the main panel"
+    "description": "Label for export data button in the footer of the main panel"
   },
 
   "exportDialogTitle": {
-    "message": "Export Data Options",
-    "description": "Title for export evaluation options dialog box"
+    "message": "Data Export Options",
+    "description": "Title for data export options dialog box"
   },
 
   "rerunEvalButtonLabel": {
@@ -606,13 +606,13 @@
   },
 
   "rerunEvalPromptForDelayLabel": {
-    "message": "After this evaluation, stop prompting for delay setting.",
+    "message": "Do not prompt for delay setting",
     "description": "Label for checkbox input in rerun evaluation dialog box"
   },
 
   "cancelButtonLabel": {
     "message": "Cancel",
-    "description": "Label for cancel button in a dialog box"
+    "description": "Label for Cancel button in a dialog box"
   },
 
   "okButtonLabel": {
@@ -623,6 +623,16 @@
   "closeButtonLabel": {
     "message": "Close",
     "description": "Label for Close button in a dialog box"
+  },
+
+  "rerunButtonLabel": {
+    "message": "Rerun",
+    "description": "Label for Rerun button in a dialog box"
+  },
+
+  "exportButtonLabel": {
+    "message": "Export",
+    "description": "Label for Export button in a dialog box"
   },
 
   "moreButtonLabel": {
@@ -642,7 +652,7 @@
 
   "optionsInclWcagGlLabel": {
     "message": "Include WCAG Guidelines",
-    "description": "Label for checkbox to include WCAG Guidleines in views menu"
+    "description": "Label for checkbox to include WCAG Guidelines in views menu"
   },
 
   "optionsInclRuleScopeLabel": {
@@ -651,7 +661,7 @@
   },
 
   "optionsRerunEvaluationLegend": {
-    "message": "Rerun Evaluation behavior",
+    "message": "Rerun Evaluation button",
     "description": "Legend for rerun evaluation section in the options page"
   },
 
@@ -661,7 +671,7 @@
   },
 
   "optionsPromptForDelayLabel": {
-    "message": "Prompt for delay settings",
+    "message": "Prompt for delay setting",
     "description": "Label for rerun with prompted delay checkbox in the options page"
   },
 
@@ -701,12 +711,12 @@
   },
 
   "optionsExportHeading": {
-    "message": "Export Data",
-    "description": "Label for file name legend in the export section of the options page"
+    "message": "Data Export",
+    "description": "Label for the data export section of the options page"
   },
 
   "optionsExportPrompt": {
-    "message": "Prompt for export options",
+    "message": "Prompt for data export options",
     "description": "Prompt for export options when the export button is pressed"
   },
 
@@ -766,7 +776,7 @@
   },
 
   "optionsExportPromptForOptions": {
-    "message": "Do not prompt for export options.",
+    "message": "Do not prompt for data export options",
     "description": "Label for disable prompting for export export file name options when activating the export button."
   },
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -636,7 +636,7 @@
   },
 
   "optionsViewsMenuLegend": {
-    "message": "'Views' Menu",
+    "message": "Views menu",
     "description": "Legend for view menu in the options page"
   },
 
@@ -651,7 +651,7 @@
   },
 
   "optionsRerunEvaluationLegend": {
-    "message": "'Rerun Evaluation' Button",
+    "message": "Rerun Evaluation behavior",
     "description": "Legend for rerun evaluation section in the options page"
   },
 
@@ -661,7 +661,7 @@
   },
 
   "optionsPromptForDelayLabel": {
-    "message": "Prompt with delay setting",
+    "message": "Prompt for delay settings",
     "description": "Label for rerun with prompted delay checkbox in the options page"
   },
 
@@ -686,12 +686,12 @@
   },
 
   "optionsRuleResultsLegend": {
-    "message": "'Rule Results' View",
+    "message": "Rule Result Types filter",
     "description": "Legend for the rule results section on the options page"
   },
 
   "optionsInclPassNaLabel": {
-    "message": "Include 'Pass' and 'N/A' results",
+    "message": "Include 'Passed' and 'Not Applicable' results",
     "description": "Label for checkbox to include pass and n/a results in the options page"
   },
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -701,7 +701,7 @@
   },
 
   "optionsExportHeading": {
-    "message": "Export",
+    "message": "Export Data",
     "description": "Label for file name legend in the export section of the options page"
   },
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -711,7 +711,7 @@
   },
 
   "optionsExportButtonLegend": {
-    "message": "'Export Data' Button",
+    "message": "Export Data button",
     "description": "Legend for prompt for export options button"
   },
 

--- a/src/options.html
+++ b/src/options.html
@@ -9,20 +9,18 @@
 
   <body>
     <form>
-      <h2>AInpsector Preferences</h2>
-
       <div class="tablist" role="tablist">
+        <div class="tab"
+             role="tab"
+             id="tab-ruleset-options"
+             aria-controls="tabpanel-ruleset-options">
+          Ruleset Options
+        </div>
         <div class="tab"
              role="tab"
              id="tab-general-options"
              aria-controls="tabpanel-general-options">
           General
-        </div>
-        <div class="tab"
-             role="tab"
-             id="tab-ruleset-options"
-             aria-controls="tabpanel-ruleset-options">
-          Ruleset
         </div>
         <div class="tab"
              role="tab"
@@ -77,12 +75,31 @@
            aria-labelledby="tab-ruleset-options">
 
         <fieldset>
-          <legend id="options-ruleset-legend">WCAG Rule Levels</legend>
+          <legend id="options-ruleset-legend">Ruleset</legend>
 
           <label>
-            <input type="radio" name="wcag-level" value="A" id="options-ruleset-level-a"/>
-            <span id="options-ruleset-level-a-only-label">Level A only</span>
+            <input type="radio" name="ruleset" value="WCAG20" id="options-ruleset-wcag20"/>
+            <span id="options-ruleset-wcag20-label">WCAG 2.0</span>
           </label>
+
+          <label>
+            <input type="radio" name="ruleset" value="WCAG21" checked id="options-ruleset-wcag21"/>
+            <span id="options-ruleset-wcag21-label">WCAG 2.1</span>
+          </label>
+
+          <label>
+            <input type="radio" name="ruleset" value="WCAG22" id="options-ruleset-wcag22"/>
+            <span id="options-ruleset-wcag22-label">WCAG 2.2</span>
+          </label>
+
+          <label>
+            <input type="radio" name="ruleset" value="FILTER" id="options-ruleset-filter"/>
+            <span id="options-ruleset-filter-label">First Step rules only</span>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend id="options-ruleset-legend">WCAG Rule Levels</legend>
 
           <label>
             <input type="radio" name="wcag-level" value="AA" id="options-ruleset-level-aa"/>
@@ -94,50 +111,30 @@
             <span id="options-ruleset-color-enhanced-label">Include Enhanced Color Contrast rule (Level AAA)</span>
           </label>
 
-        </fieldset>
-
-
-        <fieldset>
-          <legend id="options-ruleset-legend">Rulesets</legend>
-
           <label>
-            <input type="radio" name="ruleset" value="FILTER" id="options-ruleset-filter"/>
-            <span id="options-ruleset-filter-label">First step rules</span>
+            <input type="radio" name="wcag-level" value="A" id="options-ruleset-level-a"/>
+            <span id="options-ruleset-level-a-only-label">Level A only</span>
           </label>
 
-          <label>
-            <input type="radio" name="ruleset" value="WCAG20" id="options-ruleset-wcag20"/>
-            <span id="options-ruleset-wcag20-label">WCAG 2.0 ruleset</span>
-          </label>
-
-          <label>
-            <input type="radio" name="ruleset" value="WCAG21" checked id="options-ruleset-wcag21"/>
-            <span id="options-ruleset-wcag21-label">WCAG 2.1 ruleset</span>
-          </label>
-
-          <label>
-            <input type="radio" name="ruleset" value="WCAG22" id="options-ruleset-wcag22"/>
-            <span id="options-ruleset-wcag22-label">WCAG 2.2 ruleset</span>
-          </label>
         </fieldset>
 
         <fieldset>
-            <legend id="options-scope-legend">Rule Scope Filter</legend>
+            <legend id="options-scope-legend">Rule Scope filter</legend>
 
           <label>
             <input type="radio" name="scope" value="ALL" checked id="options-scope-all"/>
-            <span id="options-scope-all-label">All rule results (default)</span>
+            <span id="options-scope-all-label">All rules (Element, Page, and Website scopes)</span>
           </label>
 
           <label>
             <input type="radio" name="scope" value="PAGE" id="options-scope-page"/>
-            <span id="options-scope-page-label">Page only rule results</span>
+            <span id="options-scope-page-label">Page scope rules only</span>
           </label>
 
 
           <label>
             <input type="radio" name="scope" value="WEBSITE" id="options-scope-website"/>
-            <span id="options-scope-website-label">Website only rule results</span>
+            <span id="options-scope-website-label">Website scope rules only</span>
           </label>
         </fieldset>
       </div>

--- a/src/options.html
+++ b/src/options.html
@@ -103,7 +103,7 @@
 
           <label>
             <input type="radio" name="wcag-level" value="AA" id="options-ruleset-level-aa"/>
-            <span id="options-ruleset-level-a-only-label">Level A and AA</span>
+            <span id="options-ruleset-level-a-only-label">Levels A and AA</span>
           </label>
 
           <label style="margin-left: 2rem">

--- a/src/options.html
+++ b/src/options.html
@@ -26,7 +26,7 @@
              role="tab"
              id="tab-export-options"
              aria-controls="tabpanel-export-options">
-          Export
+          Export Data
         </div>
         <div class="tab"
              role="tab"
@@ -78,8 +78,8 @@
           <legend id="options-ruleset-legend">Ruleset</legend>
 
           <label>
-            <input type="radio" name="ruleset" value="WCAG20" id="options-ruleset-wcag20"/>
-            <span id="options-ruleset-wcag20-label">WCAG 2.0</span>
+            <input type="radio" name="ruleset" value="WCAG22" id="options-ruleset-wcag22"/>
+            <span id="options-ruleset-wcag22-label">WCAG 2.2</span>
           </label>
 
           <label>
@@ -88,13 +88,13 @@
           </label>
 
           <label>
-            <input type="radio" name="ruleset" value="WCAG22" id="options-ruleset-wcag22"/>
-            <span id="options-ruleset-wcag22-label">WCAG 2.2</span>
+            <input type="radio" name="ruleset" value="WCAG20" id="options-ruleset-wcag20"/>
+            <span id="options-ruleset-wcag20-label">WCAG 2.0</span>
           </label>
 
           <label>
             <input type="radio" name="ruleset" value="FILTER" id="options-ruleset-filter"/>
-            <span id="options-ruleset-filter-label">First Step rules only</span>
+            <span id="options-ruleset-filter-label">First Step Rules only</span>
           </label>
         </fieldset>
 

--- a/src/options.html
+++ b/src/options.html
@@ -26,7 +26,7 @@
              role="tab"
              id="tab-export-options"
              aria-controls="tabpanel-export-options">
-          Export Data
+          Data Export
         </div>
         <div class="tab"
              role="tab"
@@ -145,10 +145,10 @@
            aria-labelledby="tab-export-options">
 
         <fieldset>
-          <legend id="options-export-button-legend">'Export Data' Button</legend>
+          <legend id="options-export-button-legend">Export Data button</legend>
           <label>
             <input type="checkbox" checked id="options-export-prompt"/>
-            <span id="options-export-prompt-label">Prompt for export options</span>
+            <span id="options-export-prompt-label">Prompt for data export options</span>
           </label>
         </fieldset>
 

--- a/src/options.html
+++ b/src/options.html
@@ -38,39 +38,6 @@
 
       <div class="tabpanel"
            role="tabpanel"
-           id="tabpanel-general-options"
-           aria-labelledby="tab-general-options">
-        <fieldset>
-          <legend id="options-rule-results-legend">Rule Results</legend>
-          <label>
-            <input type="checkbox" checked id="options-incl-pass-na"/>
-            <span id="options-incl-pass-na-label">Include 'Pass' and 'N/A' results</span>
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <legend id="options-rerun-evaluation-legend">'Rerun Evaluation' Button</legend>
-          <label>
-            <input type="radio" name="delay" id="options-no-delay" checked/>
-            <span id="options-no-delay-label">Rerun with no delay</span>
-          </label>
-          <label>
-            <input type="radio" name="delay" id="options-prompt-for-delay"/>
-            <span id="options-prompt-for-delay-label">Prompt for delay setting</span>
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <legend id="options-views-menu-legend">'Views' menu</legend>
-          <label>
-            <input type="Checkbox" checked id="options-incl-wcag-gl"/>
-            <span id="options-incl-wcag-gl-label">Include WCAG Guidelines</span>
-          </label>
-        </fieldset>
-      </div>
-
-      <div class="tabpanel"
-           role="tabpanel"
            id="tabpanel-ruleset-options"
            aria-labelledby="tab-ruleset-options">
 
@@ -94,7 +61,7 @@
 
           <label>
             <input type="radio" name="ruleset" value="FILTER" id="options-ruleset-filter"/>
-            <span id="options-ruleset-filter-label">First Step Rules only</span>
+            <span id="options-ruleset-filter-label">First Step rules</span>
           </label>
         </fieldset>
 
@@ -135,6 +102,39 @@
           <label>
             <input type="radio" name="scope" value="WEBSITE" id="options-scope-website"/>
             <span id="options-scope-website-label">Website scope rules only</span>
+          </label>
+        </fieldset>
+      </div>
+
+      <div class="tabpanel"
+           role="tabpanel"
+           id="tabpanel-general-options"
+           aria-labelledby="tab-general-options">
+        <fieldset>
+          <legend id="options-rule-results-legend">Rule Results</legend>
+          <label>
+            <input type="checkbox" checked id="options-incl-pass-na"/>
+            <span id="options-incl-pass-na-label">Include 'Pass' and 'N/A' results</span>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend id="options-rerun-evaluation-legend">'Rerun Evaluation' Button</legend>
+          <label>
+            <input type="radio" name="delay" id="options-no-delay" checked/>
+            <span id="options-no-delay-label">Rerun with no delay</span>
+          </label>
+          <label>
+            <input type="radio" name="delay" id="options-prompt-for-delay"/>
+            <span id="options-prompt-for-delay-label">Prompt for delay setting</span>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend id="options-views-menu-legend">'Views' menu</legend>
+          <label>
+            <input type="Checkbox" checked id="options-incl-wcag-gl"/>
+            <span id="options-incl-wcag-gl-label">Include WCAG Guidelines</span>
           </label>
         </fieldset>
       </div>

--- a/src/sidebar/panelComponents/exportButton.js
+++ b/src/sidebar/panelComponents/exportButton.js
@@ -9,9 +9,9 @@ const getMessage = browser.i18n.getMessage;
 const msg = {
   cancelButtonLabel         : getMessage('cancelButtonLabel'),
   closeButtonLabel          : getMessage('closeButtonLabel'),
-  exportButtonLabel         : getMessage('exportButtonLabel'),
+  exportButtonLabel         : getMessage('exportDataButtonLabel'),
   exportDialogTitle         : getMessage('exportDialogTitle'),
-  okButtonLabel             : getMessage('okButtonLabel'),
+  okButtonLabel             : getMessage('exportButtonLabel'),
 
   optionsExportCSVLabel        : getMessage('optionsExportCSVLabel'),
   optionsExportFilenameLegend  : getMessage('optionsExportFilenameLegend'),

--- a/src/sidebar/panelComponents/rerunEvaluationButton.js
+++ b/src/sidebar/panelComponents/rerunEvaluationButton.js
@@ -10,7 +10,7 @@ const getMessage = browser.i18n.getMessage;
 const msg = {
   cancelButtonLabel    : getMessage('cancelButtonLabel'),
   closeButtonLabel     : getMessage('closeButtonLabel'),
-  okButtonLabel        : getMessage('okButtonLabel'),
+  okButtonLabel        : getMessage('rerunButtonLabel'),
   rerunEvalButtonLabel : getMessage('rerunEvalButtonLabel'),
   rerunEvalDialogTitle : getMessage('rerunEvalDialogTitle'),
   rerunEvalSelectLabel : getMessage('rerunEvalSelectLabel'),


### PR DESCRIPTION
### AInspector Options UI and Labeling Updates

* Deleted h2 labeled 'AInspector Options' from Preferences pane -- it seemed unnecessary/redundant.

#### Ruleset Options tab panel

* Changed tab label from 'Rulesets' to 'Ruleset Options' and moved to first tab position.
* Changed radio button group label from 'Rulesets' to 'Ruleset' and moved to first position within tab panel.
* Shortened radio button labels within Ruleset group and moved 'First Step rules only' to last position.
* Updated labeling for 'Rule Scope filter' radio buttons. See Notes #2 below.

#### General tab panel

* Changed label "'Rule Results' View" to "Rule Result Types filter". This now matches the new 'Info' dialog content.
* Changed label "Include 'Pass' and 'N/A' results" to "Include 'Passed' and 'Not Applicable' results" (also to match Info dialog content).
* Changed label "'Rerun Evaluation' Button" to "Rerun Evaluation behavior".
* Changed label "Prompt with delay settings" to "Prompt for delay settings".
* Changed label "'Views' Menu" to "Views menu".

#### Notes

1. There is a layout problem in the Preferences pane that I'm not sure how to solve: The 'Reset Defaults' button is not visible unless you scroll down (on my laptop window dimensions) on each of the tab panels, while there is considerable vertical spacing above it. It would be an improvement if it could butt up against the bottom of each tab panel's content (with some top padding or margin of course).

2. In the Rule Scopes filter radio button group, I changed the labeling such that they do not reference rule results, but rather the rules used for the evaluation. This is in contrast to the 'Rule Result Types filter' that affects only the rule result types that are displayed. I know the difference is subtle, and behind the scenes there may or may not be a difference in how the processing works, but for users, I think this is the correct distinction to make, otherwise the Rule Scope filter does not belong on the Ruleset Options tab. I think
the defining characteristic is that with rule scope, we are talking about the types of rules we want in the evaluation, as opposed the rule result types we care about on the General tab.
